### PR TITLE
feat: add --close flag

### DIFF
--- a/bin/common.js
+++ b/bin/common.js
@@ -5,13 +5,15 @@ const { createWriteStream } = require('fs');
 const { program } = require('commander');
 
 const ObserveError = require('../lib/internal/error');
+const Client = require('../lib/internal/inspector-client');
 const { startDebugger } = require('../lib/internal/utils');
 
 program
   .option('-p, --pid <pid>', 'pid of the process observe will attach to')
   .option('-h, --host <host>', 'hostname of the process observe will attach to')
   .option('-P, --port <port>', 'port of process observe will attach to')
-  .option('-f, --file <file>', 'output file, if not provided will output to stdout');
+  .option('-f, --file <file>', 'output file, if not provided will output to stdout')
+  .option('-c, --close', 'close the inspector protocol connection after done. CAUTION: this will close the inspector protocol regardless if there are other tools connected to it, and it can leave the event loop blocked indefinitely if one of the connections fails to close');
 
 function getHostPortFromArgs({ pid, host, port }) {
   if (!pid && !host && !port) {
@@ -39,7 +41,15 @@ async function runCommand(run, program) {
 
     const stream = getStreamFromArgs(args);
 
-    await run(host, port, stream, args);
+    const client = new Client(host, port);
+    await client.connect();
+
+    await run(client, stream, args);
+
+    if (args.close) {
+      await client.post("Runtime.evaluate", { expression: 'process.mainModule.require("inspector").close();' });
+    }
+    client.disconnect();
   } catch (e) {
     if (e._liberror) {
       console.error(e.message);

--- a/lib/commands/cpu-profile.js
+++ b/lib/commands/cpu-profile.js
@@ -1,11 +1,6 @@
 'use strict';
 
-const Client = require('../internal/inspector-client');
-
-async function run(host, port, stream, options={}) {
-  const client = new Client(host, port);
-  await client.connect();
-
+async function run(client, stream, options={}) {
   const duration = (options.duration || 60) * 1000;
   const interval = options.samplingInterval || undefined;
 
@@ -23,7 +18,6 @@ async function run(host, port, stream, options={}) {
   stream.write(JSON.stringify(profile));
 
   await client.post("Profiler.disable");
-  client.disconnect();
 }
 
 module.exports = { run };

--- a/lib/commands/heap-profile.js
+++ b/lib/commands/heap-profile.js
@@ -1,11 +1,6 @@
 'use strict';
 
-const Client = require('../internal/inspector-client');
-
-async function run(host, port, stream, options={}) {
-  const client = new Client(host, port);
-  await client.connect();
-
+async function run(client, stream, options={}) {
   const samplingInterval = options.samplingInterval || 512 * 1024;
   const duration = (options.duration || 60) * 1000;
 
@@ -18,8 +13,6 @@ async function run(host, port, stream, options={}) {
   const res = await client.post("HeapProfiler.stopSampling");
   const { profile } = res;
   stream.write(JSON.stringify(profile));
-
-  client.disconnect();
 }
 
 module.exports = { run };

--- a/lib/commands/heap-snapshot.js
+++ b/lib/commands/heap-snapshot.js
@@ -1,17 +1,11 @@
 'use strict';
 
-const Client = require('../internal/inspector-client');
-
-async function run(host, port, stream) {
-  const client = new Client(host, port);
-  await client.connect();
-
+async function run(client, stream) {
   await client.post("HeapProfiler.enable");
   client.on("HeapProfiler.addHeapSnapshotChunk", ({ chunk }) => {
     stream.write(chunk);
   });
   await client.post("HeapProfiler.takeHeapSnapshot");
-  await client.disconnect();
 }
 
 module.exports = { run };

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "tape test/test-*.js",
-    "coverage": "nyc tape test/test-*.js",
+    "coverage": "nyc --reporter=html tape test/test-*.js",
     "coverage-ci": "nyc --reporter=lcov tape test/test-*.js",
     "pkg": "pkg --target host --output dist/observe package.json",
     "linter": "eslint lib bin test"

--- a/test/test-cpu-profile.js
+++ b/test/test-cpu-profile.js
@@ -3,29 +3,19 @@
 const test = require('tape');
 
 const { run } = require('../lib/commands/cpu-profile');
-const { startFixtureProcess, validateCpuProfile } = require('./common');
+const { startFixtureProcess, validateCpuProfile, runCommandWithClient } = require('./common');
 
-class FakeStream {
-  constructor() {
-    this.data = '';
-  }
-
-  write(chunk) {
-    this.data += chunk;
-  }
-}
 
 test('take cpu profile', (t) => {
   const f = startFixtureProcess(t, true);
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream = new FakeStream();
     // Mock setTimeout
     const oldSetTimeout = setTimeout;
     // eslint-disable-next-line no-global-assign
     setTimeout = (fn) => oldSetTimeout(fn, 1 * 1000);
-    await run('localhost', port, stream);
+    const stream = await runCommandWithClient(run, port);
     // eslint-disable-next-line no-global-assign
     setTimeout = oldSetTimeout;
     t.notEqual(stream.data.length, 0);
@@ -41,8 +31,7 @@ test('take cpu profile with duration', (t) => {
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream = new FakeStream();
-    await run('localhost', port, stream, { duration: 1 });
+    const stream = await runCommandWithClient(run, port, { duration: 1 });
 
     t.notEqual(stream.data.length, 0);
     const result = JSON.parse(stream.data);
@@ -58,11 +47,9 @@ test('take cpu profile with samplingInterval', (t) => {
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream1 = new FakeStream();
-    await run('localhost', port, stream1, { duration: 1, samplingInterval : 1000 });
+    const stream1 = await runCommandWithClient(run, port, { duration: 1, samplingInterval : 1000 });
 
-    const stream2 = new FakeStream();
-    await run('localhost', port, stream2, { duration: 1, samplingInterval : 100 });
+    const stream2 = await runCommandWithClient(run, port, { duration: 1, samplingInterval : 100 });
 
     const { samples: samples1 } = JSON.parse(stream1.data);
     const { samples: samples2 } = JSON.parse(stream2.data);

--- a/test/test-executables.js
+++ b/test/test-executables.js
@@ -6,7 +6,8 @@ const {
   startFixtureProcess,
   runObserveExecutable,
   getPort,
-  validateCpuProfile
+  validateCpuProfile,
+  isPortInUse
 } = require('./common');
 
 test('observe heap-profile', async (t) => {
@@ -90,5 +91,20 @@ test('observe cpu-profile to file', async (t) => {
     t.ok(validateCpuProfile(result));
     f.send('exit');
     t.end();
+  });
+});
+
+test('observe --close', async (t) => {
+  const port = await getPort();
+  const f = startFixtureProcess(t, false, port);
+  f.on('ready', async () => {
+    const options = { pid: f.pid, port, options: ['-d', 1, '--close']};
+    const result = await runObserveExecutable('cpu-profile', options);
+    setTimeout(async () => {
+      t.notOk(await isPortInUse(port));
+      t.ok(validateCpuProfile(result));
+      f.send('exit');
+      t.end();
+    }, 500);
   });
 });

--- a/test/test-heap-profile.js
+++ b/test/test-heap-profile.js
@@ -3,29 +3,19 @@
 const test = require('tape');
 
 const { run } = require('../lib/commands/heap-profile');
-const { startFixtureProcess } = require('./common');
+const { startFixtureProcess, runCommandWithClient } = require('./common');
 
-class FakeStream {
-  constructor() {
-    this.data = '';
-  }
-
-  write(chunk) {
-    this.data += chunk;
-  }
-}
 
 test('take heap profile', (t) => {
   const f = startFixtureProcess(t, true);
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream = new FakeStream();
     // Mock setTimeout
     const oldSetTimeout = setTimeout;
     // eslint-disable-next-line no-global-assign
     setTimeout = (fn) => oldSetTimeout(fn, 1 * 1000);
-    await run('localhost', port, stream);
+    const stream = await runCommandWithClient(run, port);
     // eslint-disable-next-line no-global-assign
     setTimeout = oldSetTimeout;
     t.notEqual(stream.data.length, 0);
@@ -43,8 +33,7 @@ test('take heap profile with duration', (t) => {
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream = new FakeStream();
-    await run('localhost', port, stream, { duration: 1 });
+    const stream = await runCommandWithClient(run, port, { duration: 1 });
 
     t.notEqual(stream.data.length, 0);
     const { head } = JSON.parse(stream.data);
@@ -62,11 +51,10 @@ test('take heap profile with samplingInterval', (t) => {
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream1 = new FakeStream();
-    await run('localhost', port, stream1, { duration: 1, });
+    const stream1 = await runCommandWithClient(run, port, { duration: 1, });
 
-    const stream2 = new FakeStream();
-    await run('localhost', port, stream2, { duration: 1, samplingInterval : 1024 });
+
+    const stream2 = await runCommandWithClient(run, port, { duration: 1, samplingInterval : 1024 });
 
     // The second run samples 500 times more, so it's reasonable to assume more
     // frames will be captured, thus the profile should be bigger, even if it

--- a/test/test-heap-snapshot.js
+++ b/test/test-heap-snapshot.js
@@ -3,25 +3,14 @@
 const test = require('tape');
 
 const { run } = require('../lib/commands/heap-snapshot');
-const { startFixtureProcess } = require('./common');
-
-class FakeStream {
-  constructor() {
-    this.data = '';
-  }
-
-  write(chunk) {
-    this.data += chunk;
-  }
-}
+const { startFixtureProcess, runCommandWithClient } = require('./common');
 
 test('take heap snapshot', (t) => {
   const f = startFixtureProcess(t, true);
   f.on('inspectorReady', async ({ port }) => {
     t.ok(port > 0);
 
-    const stream = new FakeStream();
-    await run('localhost', port, stream);
+    const stream = await runCommandWithClient(run, port);
     t.notEqual(stream.data.length, 0);
     const { snapshot, nodes, edges, strings } = JSON.parse(stream.data);
     t.notEqual(snapshot, undefined);


### PR DESCRIPTION
Add --close flag to close inspector protocol host on the inspected
process. This might kill existing connections from other tools, or could
block the inspected process' event loop, so use at your own risk.